### PR TITLE
Fix ZuluIDE properly connecting to the Pico W

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+src/index_html.h

--- a/src/ZuluControlI2CClient.cpp
+++ b/src/ZuluControlI2CClient.cpp
@@ -174,10 +174,14 @@ void Init(uint sdaPin, uint sclPin, uint addr, uint baudrate) {
    gpio_init(sdaPin);
    gpio_set_function(sdaPin, GPIO_FUNC_I2C);
    gpio_pull_up(sdaPin);
+   // Maxing the drive strength seem to help the host connect more reliably
+   // Maxing out client side to the max sink strength to mirror the host 
+   gpio_set_drive_strength(sdaPin, GPIO_DRIVE_STRENGTH_12MA);
 
    gpio_init(sclPin);
    gpio_set_function(sclPin, GPIO_FUNC_I2C);
    gpio_pull_up(sclPin);
+   gpio_set_drive_strength(sclPin, GPIO_DRIVE_STRENGTH_12MA);
 
    i2c_init(i2c0, baudrate);
    i2c_slave_init(i2c0, addr, &i2c_slave_handler);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,8 +42,8 @@
 static const uint I2C_SLAVE_ADDRESS = 0x45;
 static const uint I2C_BAUDRATE = 100000;  // 100 kHz
 
-static const uint I2C_SLAVE_SDA_PIN = 1;  // PICO_DEFAULT_I2C_SDA_PIN; // 4
-static const uint I2C_SLAVE_SCL_PIN = 0;  // PICO_DEFAULT_I2C_SCL_PIN; // 5
+static const uint I2C_SLAVE_SDA_PIN = 0;  // PICO_DEFAULT_I2C_SDA_PIN; // 4
+static const uint I2C_SLAVE_SCL_PIN = 1;  // PICO_DEFAULT_I2C_SCL_PIN; // 5
 
 enum class ImageCacheState { Idle,
                              Fetching,
@@ -172,7 +172,12 @@ void ProcessPassword(const uint8_t *message, size_t length) {
  */
 void ProcessReset() {
    printf("Reset Received.\n");
-   watchdog_reboot(0, 0, 1000);
+   // Was set to 1 sec which was causing the controller interface to miss initialization and data
+   // transfer. Setting to 10ms for now, the wasn't any reasoning behind 10ms but it works
+   // with more SD Cards. The theory is some SD cards caused a delay of more than 1 second
+   // while the watch dog was waiting to reboot, causing the ZuluIDE not to connect. Other cards
+   // did allow the ZuluSCSI to connect to WiFi.
+   watchdog_reboot(0, 0, 10);
 }
 }  // namespace zuluide::i2c::client
 


### PR DESCRIPTION
The main issue was the reset watchdog was called when the ZuluIDE was initializing took just too long in some cases. Changing it from 1sec to 10ms fixed most of the issues with different SD cards. It also allowed the OLED controller board to be connected with HTTP PicoW to the ZuluIDE.

Also fixed was the GPIO pin number for SDA and SCL which were flipped. It had no real affect on anything as their initializing didn't care on the pin number being swapped.

Lastly edited the linker script to put most of the compiled code in the src directory in SRAM. It seemed to speed up the ZuluIDE from 9MB/s to 9.1MB/s. A small increase that can be reversed SRAM usage become much larger.