### PR TITLE
Update the Web UI, add API version checking, and encode http param for selected fileanmes correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       
@@ -44,7 +44,7 @@ jobs:
           name: ZuluIDE-HTTP-PicoW binary
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d') >> $GITHUB_OUTPUT"
       - name: Upload to latest release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 src/index_html.h
+.vscode
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,12 @@ target_include_directories(zuluide_http_picow PRIVATE
 file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/control.html FILE_CONTENT)
 file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/control.js CONTROL_JS_CONTENT)
 file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/control2.js CONTROL_2_JS_CONTENT)
+file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/version.js VERSION_JS_CONTENT)
 file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/style.css STYLE_CSS_CONTENT)
+file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/style2.css STYLE_2_CSS_CONTENT)
+file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/style3.css STYLE_3_CSS_CONTENT)
+file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/style4.css STYLE_4_CSS_CONTENT)
+file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/style_rhc.css STYLE_rhc_CSS_CONTENT)
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/src/index_html.in ${CMAKE_CURRENT_LIST_DIR}/src/index_html.h @ONLY ESCAPE_QUOTES)
 

--- a/resources/control.html
+++ b/resources/control.html
@@ -26,7 +26,7 @@
           <input type='checkbox' onclick='autoRefresh()' id='ar'>Auto Refresh</input>
         </div>
         <div id='si' class='hdn'>
-          <select id='newImg' size='10'>        
+          <select id='newImg'>
           </select><br/>
           <button class="load" onclick='loadClicked()'>Load</button><button class="cancel" onclick='cancelClicked()' style='float:right;'>Cancel</button>
         </div>

--- a/resources/control.html
+++ b/resources/control.html
@@ -1,22 +1,49 @@
+<!DOCTYPE html>
 <html>
-  <head><link rel='stylesheet' href='style.css'></head>
+  <head>
+    <meta name='viewport' content='width=device-width, initial-scale=1' />
+    <link rel='stylesheet' href='style.css' />
+    <link rel='stylesheet' href='style2.css' />
+    <link rel='stylesheet' href='style3.css' />
+    <link rel='stylesheet' href='style4.css' />
+    <link rel='stylesheet' href='style_rhc.css' />
+  </head>
   <body onload='lds()'>
-    <h1>ZuluIDE Control</h1>
-    <div id='st'>
-      Image: <span id='img'></span> <br/>
-      <button onclick='ejectClk()'>&#x23CF;</button><button onclick='selectClk()'>&#x1F4bF;</button>
-      <br/>
-      Device Type: <span id='dt'></span>
-      <hr/>
-      <button onclick='refresh()'>Refresh</button><br/>
-      <input type='checkbox' onclick='autoRefresh()' id='ar'>Auto Refresh</input>
+    <div class='row'>
+      <div class='column'>
+        <h1>ZuluIDE Control</h1>
+      </div>
     </div>
-    <div id='si' class='hdn'>
-      <select id='newImg' size='10'>        
-      </select><br/>
-      <button onclick='loadClicked()'>Load</button><button onclick='cancelClicked()' style='float:right;'>Cancel</button>
+    <div class='row'>
+      <div class='column'>
+        <div id='st'>
+          Image: <span id='img' class='wrap'></span> <br/>
+          <button onclick='ejectClk()'>&#x23CF;</button><button onclick='selectClk()'>&#x1F4bF;</button>
+          <br/>
+          Device Type: <span id='dt'></span>
+          <hr/>
+          <button onclick='refresh()'>Refresh</button><br/>
+          <input type='checkbox' onclick='autoRefresh()' id='ar'>Auto Refresh</input>
+        </div>
+        <div id='si' class='hdn'>
+          <select id='newImg' size='10'>        
+          </select><br/>
+          <button class="load" onclick='loadClicked()'>Load</button><button class="cancel" onclick='cancelClicked()' style='float:right;'>Cancel</button>
+        </div>
+      </div>
     </div>
-    <script>
+    <div class='row'>
+      <div class='column'>
+        <div id='version'>
+          <hr/>
+          Client I2C API version: <span id='cav'></span> <br/>
+          Sever I2C API version:  <span id='sav'></span> <br/>
+          <span id='avm'></span>
+        </div>
+      </div>
+    </div>
+  <script>
+      
 function lsc(flnm, old) {
   let s = document.createElement('script');
   s.type='text/javascript';
@@ -29,7 +56,8 @@ function lsc(flnm, old) {
 }
 function lds() {
   lsc('control.js', null);
-  lsc('control2.js', onload);  
+  lsc('control2.js', onload);
+  lsc('version.js', onload);
 }
     </script>
   </body>

--- a/resources/control2.js
+++ b/resources/control2.js
@@ -25,7 +25,7 @@ function cancelClicked() {
 function loadClicked() {
  let si = document.getElementById('newImg');
  fetch('image?' +  new URLSearchParams({
-  imageName: si.value
+  imageName: encodeURIComponent(si.value)
  })).then(r => r.json())
     .then(s => { if (s.status != 'ok') alert('Select failed.');} );
  showStatus();

--- a/resources/milligram.license
+++ b/resources/milligram.license
@@ -1,0 +1,9 @@
+This projects uses a modified version of
+
+Milligram v1.4.1
+https://milligram.io
+
+Copyright (c) 2020 CJ Patoilo
+Licensed under the MIT license
+
+in the fiels 'style.css' - 'style4.css'

--- a/resources/style.css
+++ b/resources/style.css
@@ -1,2 +1,67 @@
-.img {display:inline-block;}
-.hdn {display:none;}
+ *,
+ *:after,
+ *:before {
+   box-sizing: inherit;
+ }
+ 
+ html {
+   box-sizing: border-box;
+   font-size: 62.5%;
+ }
+ 
+ body {
+   color: #606c76;
+   font-family: 'Roboto', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+   font-size: 1.6em;
+   font-weight: 300;
+   letter-spacing: .01em;
+   line-height: 1.6;
+ }
+ 
+ .button,
+ button,
+ input[type='button'],
+ input[type='reset'],
+ input[type='submit'] {
+   background-color: #59a5f1;
+   border: 0.1rem solid black;
+   border-radius: .4rem;
+   color: #fff;
+   cursor: pointer;
+   display: inline-block;
+   font-size: 1.1rem;
+   font-weight: 700;
+   height: 3.8rem;
+   letter-spacing: .1rem;
+   line-height: 3.8rem;
+   padding: 0 3.0rem;
+   text-align: center;
+   text-decoration: none;
+   text-transform: uppercase;
+   white-space: nowrap;
+ }
+ 
+ .button:focus, .button:hover,
+ button:focus,
+ button:hover,
+ input[type='button']:focus,
+ input[type='button']:hover,
+ input[type='reset']:focus,
+ input[type='reset']:hover,
+ input[type='submit']:focus,
+ input[type='submit']:hover {
+   background-color: #606c76;
+   border-color: #606c76;
+   color: #fff;
+   outline: 0;
+ }
+ 
+ hr {
+   border: 0;
+   border-top: 0.1rem solid #f4f5f6;
+   margin: 3.0rem 0;
+ }
+ 
+ 
+
+

--- a/resources/style2.css
+++ b/resources/style2.css
@@ -1,0 +1,58 @@
+
+select {
+    -webkit-appearance: none;
+    background-color: transparent;
+    border: 0.1rem solid #d1d1d1;
+    border-radius: .4rem;
+    box-shadow: none;
+    box-sizing: inherit;
+    height: 3.8rem;
+    padding: .6rem 1.0rem .7rem;
+    width: 100%;
+  }
+  
+  select:focus {
+    border-color: #59a5f1;
+    outline: 0;
+  }
+  
+  select {
+    background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 8" width="30"><path fill="%23d1d1d1" d="M0,0l6,8l6-8"/></svg>') center right no-repeat;
+    padding-right: 3.0rem;
+  }
+  
+  select:focus {
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 8" width="30"><path fill="%2359a5f1" d="M0,0l6,8l6-8"/></svg>');
+  }
+  
+  select[multiple] {
+    background: none;
+    height: auto;
+  }
+  
+  label,
+  legend {
+    display: block;
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin-bottom: .5rem;
+  }
+  
+  input[type='checkbox'] {
+    display: inline;
+  }
+  
+  .label-inline {
+    display: inline-block;
+    font-weight: normal;
+    margin-left: .5rem;
+  }
+  
+  .container {
+    margin: 0 auto;
+    max-width: 112.0rem;
+    padding: 0 2.0rem;
+    position: relative;
+    width: 100%;
+  }
+  

--- a/resources/style3.css
+++ b/resources/style3.css
@@ -1,0 +1,71 @@
+
+.row {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    width: 100%;
+  }
+  
+  .row.row-no-padding {
+    padding: 0;
+  }
+  
+  .row.row-no-padding > .column {
+    padding: 0;
+  }
+  
+  .row.row-wrap {
+    flex-wrap: wrap;
+  }
+  
+  .row.row-top {
+    align-items: flex-start;
+  }
+  
+  .row.row-bottom {
+    align-items: flex-end;
+  }
+  
+  .row.row-center {
+    align-items: center;
+  }
+  
+  .row.row-stretch {
+    align-items: stretch;
+  }
+  
+  .row.row-baseline {
+    align-items: baseline;
+  }
+  
+  .row .column {
+    display: block;
+    flex: 1 1 auto;
+    margin-left: 0;
+    max-width: 100%;
+    width: 100%;
+  }
+  
+  .row .column .column-top {
+    align-self: flex-start;
+  }
+  
+  .row .column .column-bottom {
+    align-self: flex-end;
+  }
+  
+  .row .column .column-center {
+    align-self: center;
+  }
+  
+  @media (min-width: 40rem) {
+    .row {
+      flex-direction: row;
+      margin-left: -1.0rem;
+      width: calc(100% + 2.0rem);
+    }
+    .row .column {
+      margin-bottom: inherit;
+      padding: 0 1.0rem;
+    }
+  }

--- a/resources/style4.css
+++ b/resources/style4.css
@@ -1,0 +1,97 @@
+
+a {
+    color: #59a5f1;
+    text-decoration: none;
+  }
+  
+  a:focus, a:hover {
+    color: #606c76;
+  }
+  
+  .button,
+  button,
+  dd,
+  dt,
+  li {
+    margin-bottom: 1.0rem;
+  }
+  
+  fieldset,
+  input,
+  select,
+  textarea {
+    margin-bottom: 1.5rem;
+  }
+  
+  blockquote,
+  dl,
+  figure,
+  form,
+  ol,
+  p,
+  pre,
+  table,
+  ul {
+    margin-bottom: 2.5rem;
+  }
+  
+  b,
+  strong {
+    font-weight: bold;
+  }
+  
+  p {
+    margin-top: 0;
+  }
+  
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-weight: 300;
+    letter-spacing: -.1rem;
+    margin-bottom: 2.0rem;
+    margin-top: 0;
+  }
+  
+  h1 {
+    font-size: 4.6rem;
+    line-height: 1.2;
+  }
+  
+  h2 {
+    font-size: 3.6rem;
+    line-height: 1.25;
+  }
+  
+  h3 {
+    font-size: 2.8rem;
+    line-height: 1.3;
+  }
+  
+  h4 {
+    font-size: 2.2rem;
+    letter-spacing: -.08rem;
+    line-height: 1.35;
+  }
+
+  
+  img {
+    max-width: 100%;
+  }
+  
+  .clearfix:after {
+    clear: both;
+    content: ' ';
+    display: table;
+  }
+  
+  .float-left {
+    float: left;
+  }
+  
+  .float-right {
+    float: right;
+  }
+  
+  /*# sourceMappingURL=milligram.css.map */

--- a/resources/style_rhc.css
+++ b/resources/style_rhc.css
@@ -1,4 +1,3 @@
  /* (c) 2025 Copyright Rabbit Hole Computing */
- .img {display:inline-block;}
  .hdn {display:none;}
  .wrap {text-wrap:wrap;}

--- a/resources/style_rhc.css
+++ b/resources/style_rhc.css
@@ -1,0 +1,4 @@
+ /* (c) 2025 Copyright Rabbit Hole Computing */
+ .img {display:inline-block;}
+ .hdn {display:none;}
+ .wrap {text-wrap:wrap;}

--- a/resources/version.js
+++ b/resources/version.js
@@ -1,0 +1,23 @@
+function onload() {
+    setTimeout(load_version, 500);
+}
+
+function load_version()
+{
+    fetch('version')
+    .then(response => response.json())
+    .then(version => updateVersion(version));
+}
+
+function updateVersion(version) {
+    let elm = document.getElementById('cav');
+    elm.innerHTML = version.clientAPIVersion;
+    elm = document.getElementById('sav');
+    if (version.serverAPIVersion)
+     elm.innerHTML = version.serverAPIVersion;
+    if (version.message)
+    {
+     elm = document.getElementById('avm');
+     elm.innerHTML = 'Message: ' + version.message; 
+    }
+   }

--- a/src/ZuluControlI2CClient.cpp
+++ b/src/ZuluControlI2CClient.cpp
@@ -217,7 +217,9 @@ bool TryReceive(Packet** toRecv) {
 void ProcessMessages() {
    zuluide::i2c::client::Packet* toRecv;
    if (TryReceive(&toRecv)) {
-      if (Is(toRecv, I2C_SERVER_SYSTEM_STATUS_JSON)) {
+      if (Is(toRecv, I2C_SERVER_API_VERSION)) {
+         ProcessServerAPIVersion(toRecv->buffer, toRecv->length);
+      } else if (Is(toRecv, I2C_SERVER_SYSTEM_STATUS_JSON)) {
          ProcessSystemStatus(toRecv->buffer, toRecv->length);
       } else if (Is(toRecv, I2C_SERVER_IMAGE_JSON)) {
          ProcessImage(toRecv->buffer, toRecv->length);

--- a/src/ZuluControlI2CClient.h
+++ b/src/ZuluControlI2CClient.h
@@ -22,10 +22,13 @@
 #ifndef ZULU_CONTROL_I2C_CLIENT
 #define ZULU_CONTROL_I2C_CLIENT
 
+#define I2C_API_VERSION "2.0.0"
+
 #define MAX_MSG_SIZE 2048
 #define BUFFER_LENGTH 8
 #define INPUT_BUFFER_COUNT 5
 
+#define I2C_SERVER_API_VERSION  0x1
 #define I2C_SERVER_SYSTEM_STATUS_JSON 0xA
 #define I2C_SERVER_IMAGE_JSON 0xB
 #define I2C_SERVER_SSID 0xD
@@ -33,6 +36,7 @@
 #define I2C_SERVER_RESET 0xF
 
 #define I2C_CLIENT_NOOP 0x0
+#define I2C_CLIENT_API_VERSION 0x01
 #define I2C_CLIENT_SUBSCRIBE_STATUS_JSON 0xA
 #define I2C_CLIENT_LOAD_IMAGE 0xB
 #define I2C_CLIENT_EJECT_IMAGE 0xC
@@ -42,6 +46,7 @@
 #define I2C_CLIENT_FETCH_ITR_IMAGE 0x10
 #define I2C_CLIENT_IP_ADDRESS 0x11
 #define I2C_CLIENT_NET_DOWN 0x12
+
 
 #include <pico/i2c_slave.h>
 #include <pico/stdlib.h>
@@ -79,6 +84,11 @@ bool EnqueueRequest(uint8_t request);
    Enqueues a request to send to the I2C server with the provided string argument.
  */
 bool EnqueueRequest(uint8_t request, const char* toSend);
+
+/**
+   Called when the Server API version is received from the server.
+*/
+void ProcessServerAPIVersion(const uint8_t* message, size_t length);
 
 /**
    Called when a system status update is received from the I2C server.

--- a/src/index_html.in
+++ b/src/index_html.in
@@ -33,8 +33,24 @@ const char *control_2_js = R"(
 @CONTROL_2_JS_CONTENT@
 )";
 
+const char *version_js = R"(
+@VERSION_JS_CONTENT@
+)";
+
 const char *style_css = R"(
 @STYLE_CSS_CONTENT@
 )";
 
+const char *style_2_css = R"(
+@STYLE_2_CSS_CONTENT@
+)";
+const char *style_3_css = R"(
+@STYLE_3_CSS_CONTENT@
+)";
+const char *style_4_css = R"(
+@STYLE_4_CSS_CONTENT@
+)";
+const char *style_rhc_css = R"(
+@STYLE_rhc_CSS_CONTENT@
+)";
 #endif

--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -20,17 +20,17 @@
 #define MEM_LIBC_MALLOC             0
 #endif
 #define MEM_ALIGNMENT               4
-#define MEM_SIZE                    4000
-#define MEMP_NUM_TCP_SEG            32
+#define MEM_SIZE                    8000
+#define MEMP_NUM_TCP_SEG            64
 #define MEMP_NUM_ARP_QUEUE          10
 #define PBUF_POOL_SIZE              24
 #define LWIP_ARP                    1
 #define LWIP_ETHERNET               1
 #define LWIP_ICMP                   1
 #define LWIP_RAW                    1
-#define TCP_WND                     (8 * TCP_MSS)
+#define TCP_WND                     (16 * TCP_MSS)
 #define TCP_MSS                     1460
-#define TCP_SND_BUF                 (8 * TCP_MSS)
+#define TCP_SND_BUF                 (16 * TCP_MSS)
 #define TCP_SND_QUEUELEN            ((4 * (TCP_SND_BUF) + (TCP_MSS - 1)) / (TCP_MSS))
 #define LWIP_NETIF_STATUS_CALLBACK  1
 #define LWIP_NETIF_LINK_CALLBACK    1


### PR DESCRIPTION
Encode imageName url parameter string
This is for issue: https://github.com/ZuluIDE/ZuluIDE-firmware/issues/192
Filenames with "&" fail to load via the web interface with a PicoW
control board.

The issue is the filename string was being sent as a url without being
encoded. Since "&" is special character as a URL parameter the
string wasn't being received properly by the ZuluIDE.

Now encoding URL parameter in the repo and escaping the url in the
ZuluIDE firmware.


Added css styling, fixed web asset not loading
The biggest change is adding styling to the webpage.  This was rather
difficult because the lwip httpd wasn't allowing for assets larger than
around 1.5k. This required splitting the Milligram css library into
multiple files. This was rather slow, but using this as a guide
https://forums.raspberrypi.com/viewtopic.php?t=363823
modifying the `lwipotps.h` file speed things up a bit.

Some assets weren't loading because the cgi handler used a fixed value
array count. This was fixed by using
`sizeof(cgi_handlers)/sizeof(cgi_handlers[0])` so the size updates with
a hard coded value.

Added newlines to log messages about API versions conflicting.



