### PR TITLE
Pass through invalid %-sequences in urldecode

### DIFF
--- a/src/url_decode.cpp
+++ b/src/url_decode.cpp
@@ -33,10 +33,17 @@ void urldecode(char *str) {
          }
 
          case '%': {
-            if (sscanf(str + read + 1, "%2hhx", str + write) > 0) {
-                read += 2;
-                write++;
+            // If there are 2 more chars and they're hex digits
+            if (
+                (read + 2) < len
+                && isxdigit(str[read + 1])
+                && isxdigit(str[read + 2])
+            ) {
+                // Skip the %
+                read++;
+                sscanf(str + read++, "%2hhx", str + write++);
             }
+            // Pass the %
             else {
                 str[write++] = '%';
             }

--- a/src/url_decode.cpp
+++ b/src/url_decode.cpp
@@ -33,9 +33,13 @@ void urldecode(char *str) {
          }
 
          case '%': {
-            // Skip the %
-            read++;
-            sscanf(str + read++, "%2hhx", str + write++);
+            if (sscanf(str + read + 1, "%2hhx", str + write) > 0) {
+                read += 2;
+                write++;
+            }
+            else {
+                str[write++] = '%';
+            }
             break;
          }
 

--- a/src/url_decode.cpp
+++ b/src/url_decode.cpp
@@ -22,6 +22,7 @@
 #include "url_decode.h"
 
 void urldecode(char *str) {
+   if (!str) return;
    int len = strlen(str);
    int write = 0;
    for (int read = 0; read < len; read++) {

--- a/src/url_decode.h
+++ b/src/url_decode.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <ctype.h>
 
 void urldecode(char *str);
 


### PR DESCRIPTION
I wrote a test suite for this repo's `urldecode` function using Python and ctypes (which I won't burden you with - though I would be happy to share test cases in any form preferred.)

Overall, `urldecode` works well for valid and reasonable inputs. And I don't see that this unit has a strong contract to make any miracles happen with bad inputs. However, I did find a few cases where the simplest sscanf approach will act odd and on the basis of those cases I developed the little patches in this PR.

The commits contain extensive explanations which are beyond verbose. If you decide to take the patches, feel free to squash/edit. And I do not care in the slightest if you use my patches or if my name gets attached to anything. Feel free to use any of the changes I have attached to this PR in any way you see fit, including "stealing" the code with copy-paste and closing the PR. :)

But, please review and test before dumping this on other people.

I definitely think there are style improvements which could be made to the stuff I wrote around sscanf.

While I'm very much a beginner with the pico and its build chain, I believe I was successful in flashing the Pico W with an image built with this code, booting up my ZuluIDE, then using the HTTP API to switch the image to "Quake%A" (exactly matching a directory of that name on the SD card). However, I haven't done any integration testing beyond that, so it's always possible I overlooked something.