### PR TITLE
Fix urldecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
 src/index_html.h
+test/*_test
 .vscode
 

--- a/src/url_decode.cpp
+++ b/src/url_decode.cpp
@@ -21,6 +21,13 @@
 
 #include "url_decode.h"
 
+int hexToInt(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
 void urldecode(char *str) {
    if (!str) return;
    int len = strlen(str);
@@ -39,9 +46,9 @@ void urldecode(char *str) {
                 && isxdigit(str[read + 1])
                 && isxdigit(str[read + 2])
             ) {
-                // Skip the %
-                read++;
-                sscanf(str + read++, "%2hhx", str + write++);
+                // scanff with %2hhx does not work correctly when run on the RP2040
+                str[write++] = (hexToInt(str[read+1]) << 4) + hexToInt(str[read+2]);
+                read+=2;
             }
             // Pass the %
             else {

--- a/src/url_decode.h
+++ b/src/url_decode.h
@@ -22,9 +22,7 @@
 #ifndef URL_DECODE_H
 #define URL_DECODE_H
 
-#include <cstdint>
 #include <cstring>
-#include <iostream>
 #include <ctype.h>
 
 void urldecode(char *str);

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,7 @@
+# Run basic unit tests for the zuluide-http-picow
+
+all: url_decode_test
+	./url_decode_test
+
+url_decode_test: url_decode_test.cpp ../src/url_decode.cpp
+	g++ -Wall -Wextra -g -ggdb -o $@ -I ../src $^

--- a/test/url_decode_test.cpp
+++ b/test/url_decode_test.cpp
@@ -1,0 +1,74 @@
+#include "url_decode.h"
+#include <stdio.h>
+#include <string.h>
+
+/* Unit test helpers */
+#define COMMENT(x) printf("\n----" x "----\n");
+#define TEST(x) \
+    if (!(x)) { \
+        fprintf(stderr, "\033[31;1mFAILED:\033[22;39m %s:%d %s\n", __FILE__, __LINE__, #x); \
+        status = false; \
+    } else { \
+        printf("\033[32;1mOK:\033[22;39m %s\n", #x); \
+    }
+
+bool test_basics()
+{
+    bool status = true;
+    char value[] = "Game+%28USA%2C+Europe%29";
+
+    COMMENT("test_basics()");
+    urldecode(value);
+    TEST(strcmp(value, "Game (USA, Europe)") == 0);
+    return status;
+}
+
+
+bool test_case_insensitive()
+{
+    bool status = true;
+    char value[] = "%2c%2C";
+
+    COMMENT("test_case_insensitive()");
+    urldecode(value);
+    TEST(strcmp(value, ",,") == 0);
+    return status;
+}
+
+
+bool test_invalid_escape()
+{
+    bool status = true;
+    char value[] = "%%28%2G%g2%29%";
+
+    COMMENT("test_invalid_escape()");
+    urldecode(value);
+    TEST(strcmp(value, "%(%2G%g2)%") == 0);
+    return status;
+}
+
+
+bool test_no_escape()
+{
+    bool status = true;
+    char value[] = "Game.iso";
+
+    COMMENT("test_no_escape()");
+    urldecode(value);
+    TEST(strcmp(value, "Game.iso") == 0);
+    return status;
+}
+
+
+int main()
+{
+    if (test_basics() && test_case_insensitive() && test_invalid_escape() && test_no_escape())
+    {
+        return 0;
+    }
+    else
+    {
+        printf("Some tests failed\n");
+        return 1;
+    }
+}


### PR DESCRIPTION
Fixes `urldecode` to work correctly when run on the RP2040 itself.

Previously, image paths containing percent-escaped characters would fail to load. The tests I added in this commit passed on tag release-2025-07-17-1 when run on my desktop, but there was a different, broken behavior on the RP2040 itself. Examples from the serial console:

    Setting image to: Game %USAS Europer
    Setting image to: Rebel Moon Rising %USAS %En+Fr8De%EsFIt2
    Setting image to: Windows 98 Second Edition %OEME.iso

After this commit's change, `urldecode` works as expected on both my desktop and the RP2040.

    Setting image to: Game (USA, Europe)
    Setting image to: Rebel Moon Rising (USA) (En,Fr,De,Es,It)
    Setting image to: Windows 98 Second Edition (OEM).iso

I'm not sure why exactly `sscanf` did not work correctly, but some vague searches seem to indicate that the `hh` modifier of `%2hhx` is not supported by the pi pico sdk.

The test structure was copied from the cueparser library.