### PR TITLE
Add universal binary build for PicoW/Pico2W

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,38 +19,41 @@ jobs:
         working-directory: pico-sdk
         run: git submodule update --init
 
-      - name: Create build Directory
-        run: cmake -E make_directory build
-        
       - name: Setup Tools
         run: |
            sudo apt update
            sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
            
-      - name: Configure CMake
-        working-directory: ${{github.workspace}}/build
+      - name: Build
         env:
           PICO_SDK_PATH: ${{github.workspace}}/pico-sdk
-        run: cmake ../
-
-      - name: Build
-        working-directory: ${{github.workspace}}/build
-        run: cmake --build .
+        run: |
+          cd universal_binary
+          cmake -B build
+          cmake --build build
 
       - name: Upload UF2 into build artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{github.workspace}}/build/zuluide_http_picow.uf2
-          name: ZuluIDE-HTTP-PicoW binary
+          path: ${{github.workspace}}/universal_binary/build/zuluide_http_picow.uf2
+          name: ZuluIDE-HTTP-PicoW Pico2W universal binary
+
+      - name: Upload ELFs into build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{github.workspace}}/universal_binary/build/platform_*/*.elf
+          name: Debugging symbols
+
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
       - name: Upload to latest release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.ref == 'refs/heads/main'
         run: |
-          cd build
+          cd universal_binary/build
           gh release create  --latest --repo ${GITHUB_REPOSITORY} release-${{steps.date.outputs.date}}-${{github.run_attempt}} zuluide_http_picow.uf2
 
       - name: Upload to newly created release
@@ -59,4 +62,5 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           RELEASE=$(basename ${{github.ref}})
-          gh release upload --repo ${GITHUB_REPOSITORY} $RELEASE *
+          cd universal_binary/build
+          gh release upload --repo ${GITHUB_REPOSITORY} $RELEASE * zuluide_http_picow.uf2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,10 @@ endif()
 # ====================================================================================
 cmake_minimum_required(VERSION 3.25)
 
-set(PICO_BOARD pico_w)
+if(NOT DEFINED PICO_BOARD)
+    set(PICO_BOARD pico_w)
+endif()
+
 include(pico_sdk_import.cmake)
 
 project(zuluide_http_picow C CXX ASM)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ After you have setup the SDK and build tools run the following instructions:
 
 1. Obtain the ZuluIDE-HTTP-PicoW repository by running: `git clone git@github.com:ZuluIDE/ZuluIDE-HTTP-PicoW.git`
 2. From within a terminal, change to the directory containing the ZuluIDE-HTTP-PicoW repository
-3. Make a build directory ( `mkdir build`) and then change to that directory (`cd build`)
-4. Run `cmake ..`
-5. Run `make`
+3. Configure the project with `cmake -B build -DPICO_BOARD=pico_w` (or `pico2_w`)
+4. Build the project with `cmake --build build`
 
 After doing this, you should find the `zuluide_http_picow.uf2` file in the build directory.
+
+To build an universal binary that works on both PicoW and Pico2W, see [universal_binary/CMakeLists.txt](universal_binary/CMakeLists.txt).
 
 ## Configuring WiFi Settings on ZuluIDE SD Card
 

--- a/universal_binary/CMakeLists.txt
+++ b/universal_binary/CMakeLists.txt
@@ -1,0 +1,45 @@
+# This builds an universal binary that works for both PicoW and Pico2W.
+# During development you can use individual builds by defining PICO_BOARD
+# for the root folder CMakeLists.txt:
+#
+# cmake -B build -DPICO_BOARD=pico2_w; cmake --build build
+#
+# To build the universal binary, run cmake in the universal_binary directory:
+#
+# cd universal_binary
+# cmake -B build; cmake --build build
+
+cmake_minimum_required(VERSION 3.25)
+project(zuluide_http_picow_universal C CXX ASM)
+include(ExternalProject)
+
+ExternalProject_Add(platform_picow
+            SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..
+            BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/platform_picow
+            CMAKE_ARGS
+                "-DPICO_BOARD=pico_w"
+            BUILD_ALWAYS 1 # force dependency checking
+            INSTALL_COMMAND ""
+)
+
+ExternalProject_Add(platform_pico2w
+            SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..
+            BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/platform_pico2w
+            CMAKE_ARGS
+                "-DPICO_BOARD=pico2_w"
+            BUILD_ALWAYS 1 # force dependency checking
+            INSTALL_COMMAND ""
+)
+
+set(COMBINED_UF2 zuluide_http_picow.uf2)
+set(PLATFORM_UF2s ${CMAKE_CURRENT_BINARY_DIR}/platform_picow/zuluide_http_picow.uf2 ${CMAKE_CURRENT_BINARY_DIR}/platform_pico2w/zuluide_http_picow.uf2)
+
+add_custom_command(
+    OUTPUT ${COMBINED_UF2}
+    COMMAND ${CMAKE_COMMAND} -E cat ${PLATFORM_UF2s} > ${COMBINED_UF2}
+    DEPENDS ${PLATFORM_UF2s}
+)
+
+add_custom_target(platform_combined ALL
+    DEPENDS ${COMBINED_UF2}
+)


### PR DESCRIPTION
This should build an .uf2 that can be flashed to either PicoW or Pico2W.

I don't currently have any Pico2W so I only tested that it flashes and boots on PicoW.