### PR TITLE
Implement firmware upgrade over WiFi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,20 @@ file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/version.js VERSION_JS_CONTENT)
 file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/style.css STYLE_CSS_CONTENT)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/src/index_html.in ${CMAKE_CURRENT_LIST_DIR}/src/index_html.h @ONLY ESCAPE_QUOTES)
 
+# Try to get git hash for version number
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE FW_GITHASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE GIT_RESULT
+    ERROR_QUIET
+)
+
+if(GIT_RESULT EQUAL 0)
+    add_compile_definitions(FW_GITHASH="${FW_GITHASH}")
+endif()
+
 
 target_compile_definitions(zuluide_http_picow PRIVATE
         WIFI_PASSWORD=\"${WIFI_PASSWORD}\"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,12 @@ pico_sdk_init()
 
 add_executable(zuluide_http_picow)
 
-target_sources(zuluide_http_picow PRIVATE src/main.cpp src/url_decode.cpp src/ZuluControlI2CClient.cpp)
+target_sources(zuluide_http_picow PRIVATE
+    src/main.cpp
+    src/url_decode.cpp
+    src/ZuluControlI2CClient.cpp
+    src/fw_upgrade.cpp
+)
 
 #pico_enable_stdio_uart(zuluide_http_picow ENABLED)
 pico_enable_stdio_usb(zuluide_http_picow ENABLED)
@@ -44,11 +49,27 @@ target_include_directories(zuluide_http_picow PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src
         )
 
-file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/control.html FILE_CONTENT)
-file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/control.js CONTROL_JS_CONTENT)
-file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/version.js VERSION_JS_CONTENT)
-file(READ ${CMAKE_CURRENT_LIST_DIR}/resources/style.css STYLE_CSS_CONTENT)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/src/index_html.in ${CMAKE_CURRENT_LIST_DIR}/src/index_html.h @ONLY ESCAPE_QUOTES)
+set(RESOURCE_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/resources/control.html
+    ${CMAKE_CURRENT_LIST_DIR}/resources/fw_upgrade.html
+    ${CMAKE_CURRENT_LIST_DIR}/resources/control.js
+    ${CMAKE_CURRENT_LIST_DIR}/resources/version.js
+    ${CMAKE_CURRENT_LIST_DIR}/resources/style.css
+)
+
+foreach(f IN LISTS RESOURCE_FILES)
+    get_filename_component(name ${f} NAME)
+    string(REPLACE "." "_" var ${name})
+    string(TOUPPER ${var} var)
+    file(READ ${f} ${var}_CONTENT)
+endforeach()
+
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${RESOURCE_FILES})
+configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/src/index_html.in
+    ${CMAKE_CURRENT_LIST_DIR}/src/index_html.h
+    @ONLY
+)
 
 # Try to get git hash for version number
 execute_process(
@@ -75,4 +96,6 @@ target_link_libraries(zuluide_http_picow
         pico_multicore
         pico_stdlib
         pico_lwip_http
-        pico_cyw43_arch_lwip_threadsafe_background)
+        boot_uf2_headers
+        pico_cyw43_arch_lwip_threadsafe_background
+)

--- a/resources/control.html
+++ b/resources/control.html
@@ -43,8 +43,7 @@
       <div class='column'>
         <div id='version'>
           <hr/>
-          Client I2C API version: <span id='cav'></span> <br/>
-          Sever I2C API version:  <span id='sav'></span> <br/>
+          I2C API version: client <span id='cav'></span>, server <span id='sav'></span>, ZuluIDE HTTP firmware <span id='cfv'></span> <br/>
           <span id='avm'></span>
         </div>
       </div>

--- a/resources/control.html
+++ b/resources/control.html
@@ -45,6 +45,7 @@
           <hr/>
           I2C API version: client <span id='cav'></span>, server <span id='sav'></span>, ZuluIDE HTTP firmware <span id='cfv'></span> <br/>
           <span id='avm'></span>
+          <a href="fw_upgrade.html">Upgrade...</a>
         </div>
       </div>
     </div>

--- a/resources/fw_upgrade.html
+++ b/resources/fw_upgrade.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name='viewport' content='width=device-width, initial-scale=1' />
+    <script type='text/javascript' src='version.js'></script>
+    <link rel='stylesheet' href='style.css' />  </head>
+  <body>
+    <div class='row'>
+        <div class='column'>
+            <h1>ZuluIDE HTTP Control Interface Firmware Upgrade</h1>
+        </div>
+    </div>
+    <div class='row'>
+        <div class='column'>
+            <p>
+                To upgrade the firmware running on the Pico W or Pico2 W board for ZuluIDE HTTP user interface,
+                please upload the file <code>zuluide_http_picow.uf2</code>.
+            </p>
+            <p>Current firmware version: <span id='cfv'></span></p>
+            <p>
+                <form id="uploadForm">
+                    <label for="fileInput">Firmware file:</label>
+                    <input id="fileInput" type="file" />
+                    <input type="submit" value="Upgrade" />
+                </form>
+            </p>
+            <p id="progress" style="display: none">
+              <progress id="progressBar" value="0" max="100"></progress>
+              <span id="progressText">0%</span>
+            </p>
+        </div>
+    </div>
+  </body>
+  <script>
+    var rebootDelay = 10;
+
+    function rebootWait()
+    {
+      const progressText = document.getElementById("progressText");
+      progressText.textContent = "Upload complete, please wait for reboot.. " + rebootDelay;
+
+      rebootDelay--;
+      if (rebootDelay == 0)
+      {
+        document.location = '/';
+      }
+      else
+      {
+        setTimeout(rebootWait, 1000);
+      }
+    }
+
+    document.getElementById("uploadForm").addEventListener("submit", function(e) {
+      e.preventDefault();
+
+      const file = document.getElementById("fileInput").files[0];
+
+      document.getElementById('progress').style.display = 'block';
+
+      const progressBar = document.getElementById("progressBar");
+      const progressText = document.getElementById("progressText");
+
+      const xhr = new XMLHttpRequest();
+
+      xhr.open("POST", "/fw_upgrade.cgi");
+      xhr.setRequestHeader("Content-Type", "application/octet-stream");
+
+      xhr.upload.onprogress = function(event) {
+        if (event.lengthComputable) {
+          const percent = Math.round((event.loaded / event.total) * 100);
+          progressBar.value = percent;
+          progressText.textContent = percent + "%";
+        }
+      };
+
+      xhr.onload = function() {
+        progressBar.value = 100;
+        if (xhr.status === 200) {
+          rebootWait();
+        } else {
+          progressText.textContent = "Upload failed";
+        }
+      };
+
+      xhr.onerror = function() {
+        progressText.textContent = "Upload error";
+      };
+
+      xhr.send(file);
+    });
+  </script>
+</html>

--- a/resources/version.js
+++ b/resources/version.js
@@ -12,6 +12,8 @@ function load_version()
 function updateVersion(version) {
     let elm = document.getElementById('cav');
     elm.innerHTML = version.clientAPIVersion;
+    elm = document.getElementById('cfv');
+    elm.innerHTML = version.clientFWVersion;
     elm = document.getElementById('sav');
     if (version.serverAPIVersion)
      elm.innerHTML = version.serverAPIVersion;

--- a/resources/version.js
+++ b/resources/version.js
@@ -11,15 +11,18 @@ function load_version()
 
 function updateVersion(version) {
     let elm = document.getElementById('cav');
-    elm.innerHTML = version.clientAPIVersion;
+    if (elm) elm.innerHTML = version.clientAPIVersion;
+
     elm = document.getElementById('cfv');
-    elm.innerHTML = version.clientFWVersion;
+    if (elm) elm.innerHTML = version.clientFWVersion;
+
     elm = document.getElementById('sav');
-    if (version.serverAPIVersion)
+    if (elm && version.serverAPIVersion)
      elm.innerHTML = version.serverAPIVersion;
+
     if (version.message)
     {
      elm = document.getElementById('avm');
-     elm.innerHTML = 'Message: ' + version.message; 
+     if (elm) elm.innerHTML = 'Message: ' + version.message;
     }
 }

--- a/src/ZuluControlI2CClient.h
+++ b/src/ZuluControlI2CClient.h
@@ -24,6 +24,12 @@
 
 #define I2C_API_VERSION "3.0.1"
 
+#ifndef FW_GITHASH
+#define FW_GITHASH ""
+#endif
+
+#define FW_VERSION __DATE__ " " FW_GITHASH
+
 #define MAX_MSG_SIZE 2048
 #define FILENAMES_JSON_CACHE_SIZE 51200
 #define BUFFER_LENGTH 8

--- a/src/fw_upgrade.cpp
+++ b/src/fw_upgrade.cpp
@@ -1,0 +1,262 @@
+/**
+ * ZuluIDE™ - Copyright (c) 2023 Rabbit Hole Computing™
+ *
+ * ZuluIDE™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+#include "fw_upgrade.h"
+#include <hardware/sync.h>
+#include <hardware/flash.h>
+#include <hardware/structs/scb.h>
+#include <pico/multicore.h>
+#include "lwip/apps/fs.h"
+#include "lwip/apps/httpd.h"
+#include "lwip/def.h"
+#include "lwip/mem.h"
+#include "lwip/opt.h"
+#include "boot/uf2.h"
+#include <string.h>
+
+#if PICO_RP2350
+#define UF2_FAMILY_ID RP2350_ARM_S_FAMILY_ID
+#else
+#define UF2_FAMILY_ID RP2040_FAMILY_ID
+#endif
+
+// This is constant for RP2xxx
+#define UF2_PAYLOAD_SIZE 256
+
+// Uploaded data is temporarily stored at 1 MB offset from flash start.
+// It is only flashed to main location after the whole image is successfully received.
+#define FW_UPGRADE_TEMP_OFFSET (1024 * 1024)
+#define FW_UPGRADE_TARGET_ADDR 0x10000000
+
+// 4kB erase blocks are large enough for all flash chips
+#define FLASH_SECTOR_ERASE_SIZE 4096u
+
+static struct {
+    size_t block_size;
+    uf2_block block;
+    uint32_t blocks_received;
+    uint32_t num_blocks;
+} g_fwup_state;
+
+err_t fwupgrade_post_begin(void *connection, const char *uri, const char *http_request,
+                       u16_t http_request_len, int content_len, char *response_uri,
+                       u16_t response_uri_len, u8_t *post_auto_wnd)
+{
+    printf("fwupgrade_post_begin %s\n", uri);
+    g_fwup_state.block_size = 0;
+    g_fwup_state.blocks_received = 0;
+    g_fwup_state.num_blocks = 0;
+    return ERR_OK;
+}
+
+// Erase whole flash area before programming it
+__attribute__((section(".time_critical.erase_flash_area")))
+static void erase_flash_area(uint32_t offset, uint32_t len)
+{
+    if (len % FLASH_SECTOR_ERASE_SIZE != 0)
+    {
+        len += FLASH_SECTOR_ERASE_SIZE - (len % FLASH_SECTOR_ERASE_SIZE);
+    }
+
+    uint32_t saved_irq = save_and_disable_interrupts();
+    flash_range_erase(offset, len);
+    restore_interrupts(saved_irq);
+}
+
+// Program one flash block
+__attribute__((section(".time_critical.program_flash_block")))
+static bool program_flash_block(uint32_t offset, uint8_t *data)
+{
+    uint32_t saved_irq = save_and_disable_interrupts();
+    flash_range_program(offset, data, UF2_PAYLOAD_SIZE);
+    restore_interrupts(saved_irq);
+    bool success = (memcmp(data, (void*)(XIP_NOCACHE_NOALLOC_BASE + offset), UF2_PAYLOAD_SIZE) == 0);
+    return success;
+}
+
+// Copy firmware from temporary area to final flash location.
+// Note: this must be fully in RAM and not call any flash functions,
+// because the flash is being overwritten.
+__attribute__((section(".time_critical.finish_fw_upgrade")))
+int64_t finish_fw_upgrade(alarm_id_t id, void *user_data)
+{
+    uint32_t total_fw_size = g_fwup_state.num_blocks * UF2_PAYLOAD_SIZE;
+    if (total_fw_size < 16 * 1024 ||
+        total_fw_size > FW_UPGRADE_TEMP_OFFSET)
+    {
+        return 0; // Just a sanity check
+    }
+
+    save_and_disable_interrupts();
+
+    // Copy firmware from temp area to the final offset
+    erase_flash_area(0, total_fw_size);
+    for (uint32_t block = 0; block < g_fwup_state.num_blocks; block++)
+    {
+        // We need to copy each block to RAM and from there back to flash
+        // at the final location. But memcpy might not be in RAM, so do it manually.
+        uint8_t buf[UF2_PAYLOAD_SIZE];
+        uint32_t offset = block * UF2_PAYLOAD_SIZE;
+        uint8_t *src = (uint8_t*)(FW_UPGRADE_TARGET_ADDR + FW_UPGRADE_TEMP_OFFSET + offset);
+        for (size_t i = 0; i < UF2_PAYLOAD_SIZE; i++)
+        {
+            buf[i] = src[i];
+        }
+
+        flash_range_program(offset, buf, UF2_PAYLOAD_SIZE);
+    }
+
+    // Reboot
+    scb_hw->aircr = 0x05FA0004;
+    while(1);
+}
+
+static bool handle_uf2_block(uf2_block *block)
+{
+    if (block->magic_start0 != UF2_MAGIC_START0 ||
+        block->magic_start1 != UF2_MAGIC_START1 ||
+        block->magic_end != UF2_MAGIC_END)
+    {
+        printf("UF2 magics do not match (0x%08lx 0x%08lx 0x%08lx)\n",
+            block->magic_start0, block->magic_start1, block->magic_end);
+        return false;
+    }
+
+    if (block->file_size != UF2_FAMILY_ID || !(block->flags & UF2_FLAG_FAMILY_ID_PRESENT))
+    {
+        printf("Ignoring block for different family id (expected 0x%08x, got 0x%08lx)\n",
+            UF2_FAMILY_ID, block->file_size);
+
+        // Continue upload until we get a block for us in a universal binary
+        return true;
+    }
+
+    if (block->flags & UF2_FLAG_NOT_MAIN_FLASH)
+    {
+        printf("Ignoring not-for-flash UF2 block\n");
+        return true;
+    }
+
+    if (block->payload_size != UF2_PAYLOAD_SIZE)
+    {
+        printf("Unexpected payload size %lu\n", block->payload_size);
+        return false;
+    }
+
+    if (block->target_addr < FW_UPGRADE_TARGET_ADDR ||
+        block->target_addr >= FW_UPGRADE_TARGET_ADDR + FW_UPGRADE_TEMP_OFFSET)
+    {
+        printf("UF2 block offset out of range: 0x%08lx\n", block->target_addr);
+        return false;
+    }
+
+    if (block->block_no == 0)
+    {
+        printf("Got first UF2 block, total %lu blocks\n", block->num_blocks);
+        g_fwup_state.blocks_received = 0;
+        g_fwup_state.num_blocks = block->num_blocks;
+
+        printf("Stopping second core");
+        multicore_reset_core1();
+
+        uint32_t total_bytes = block->num_blocks * UF2_PAYLOAD_SIZE;
+        printf("Erasing temp area for %lu bytes\n", total_bytes);
+        erase_flash_area(FW_UPGRADE_TEMP_OFFSET, total_bytes);
+    }
+    else if (block->block_no != g_fwup_state.blocks_received)
+    {
+        printf("UF2 block out of order, got %lu expected %lu\n",
+            block->block_no, g_fwup_state.blocks_received);
+        return false;
+    }
+
+    uint32_t block_offset = block->target_addr - FW_UPGRADE_TARGET_ADDR;
+    uint32_t tmp_addr = FW_UPGRADE_TEMP_OFFSET + block_offset;
+    printf("Programming UF2 block %lu/%lu to %lu\n", block->block_no, block->num_blocks, tmp_addr);
+    if (!program_flash_block(tmp_addr, block->data))
+    {
+        printf("Programming UF2 block to temporary flash failed at addr %lu\n", tmp_addr);
+        return false;
+    }
+    printf("Block programming successful\n");
+    g_fwup_state.blocks_received++;
+
+    return true;
+}
+
+err_t fwupgrade_post_receive_data(void *connection, struct pbuf *p)
+{
+    uint8_t *data = (uint8_t*)p->payload;
+    printf("fwupgrade_post_receive_data %d 0x%02x 0x%02x\n", (int)p->len, data[0], data[1]);
+
+    // Process one UF2 block at a time.
+    // For RP2xxx the UF2 blocks are always 512 bytes in size.
+    size_t remain = p->len;
+    while (remain > 0)
+    {
+        size_t block_remain = sizeof(uf2_block) - g_fwup_state.block_size;
+        size_t to_cpy = (remain > block_remain) ? block_remain : remain;
+        memcpy((uint8_t*)&g_fwup_state.block + g_fwup_state.block_size, data, to_cpy);
+        g_fwup_state.block_size += to_cpy;
+        data += to_cpy;
+        remain -= to_cpy;
+
+        if (g_fwup_state.block_size == sizeof(uf2_block))
+        {
+            if (!handle_uf2_block(&g_fwup_state.block))
+            {
+                printf("handle_uf2_block() failed\n");
+                return ERR_VAL;
+            }
+            g_fwup_state.block_size = 0;
+        }
+    }
+
+    pbuf_free(p);
+    return ERR_OK;
+}
+
+void start_multicore_i2c();
+
+void fwupgrade_post_finished(void *connection, char *response_uri, u16_t response_uri_len)
+{
+    if (g_fwup_state.num_blocks == 0 ||
+        g_fwup_state.blocks_received != g_fwup_state.num_blocks)
+    {
+        printf("fwupgrade interrupted, %lu/%lu blocks done\n",
+            g_fwup_state.blocks_received, g_fwup_state.num_blocks);
+
+        if (g_fwup_state.num_blocks > 0)
+        {
+            // We reset multicore so restore it back to operation
+            start_multicore_i2c();
+        }
+    }
+    else
+    {
+        printf("fwupgrade_post_finished\n");
+        snprintf(response_uri, response_uri_len, "/fw_upgrade.html");
+
+        // Let lwip post the result and then proceed to copy the firmware to the actual
+        // location and reboot.
+        add_alarm_in_ms(500, finish_fw_upgrade, NULL, false);
+    }
+}

--- a/src/fw_upgrade.h
+++ b/src/fw_upgrade.h
@@ -17,28 +17,21 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
-**/
-#ifndef INDEX_HTML_H
-#define INDEX_HTML_H
+ **/
 
-const char index_html[] =  R"(
-@CONTROL_HTML_CONTENT@
-)";
+#pragma once
 
-const char fw_upgrade_html[] =  R"(
-@FW_UPGRADE_HTML_CONTENT@
-)";
+#include "lwip/apps/httpd.h"
 
-const char control_js[] = R"(
-@CONTROL_JS_CONTENT@
-)";
+// This module defines handlers for HTTP POST requests used for firmware upgrade
 
-const char version_js[] = R"(
-@VERSION_JS_CONTENT@
-)";
+// Called from httpd_post_begin()
+err_t fwupgrade_post_begin(void *connection, const char *uri, const char *http_request,
+                       u16_t http_request_len, int content_len, char *response_uri,
+                       u16_t response_uri_len, u8_t *post_auto_wnd);
 
-const char style_css[] = R"(
-@STYLE_CSS_CONTENT@
-)";
+// Called from httpd_post_receive_data
+err_t fwupgrade_post_receive_data(void *connection, struct pbuf *p);
 
-#endif
+// Called from http_post_finished
+void fwupgrade_post_finished(void *connection, char *response_uri, u16_t response_uri_len);

--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -56,6 +56,7 @@
 #define LWIP_HTTPD_DYNAMIC_FILE_READ 1 
 #define LWIP_HTTPD_DYNAMIC_HEADERS  1
 #define LWIP_HTTPD_FILE_EXTENSION   1
+#define LWIP_HTTPD_SUPPORT_POST     1
 
 #ifndef NDEBUG
 #define LWIP_DEBUG                  1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 
 #include "ZuluControlI2CClient.h"
 #include "index_html.h"
+#include "fw_upgrade.h"
 #include "lwip/apps/fs.h"
 #include "lwip/apps/httpd.h"
 #include "lwip/def.h"
@@ -436,6 +437,8 @@ static const char *cgi_handler_eject(int index, int numParams, char *params[], c
    zuluide::i2c::client::EnqueueRequest(I2C_CLIENT_EJECT_IMAGE);
    return "/ok.json";
 }
+
+
 static const tCGI cgi_handlers[] = {
                                     {"/version", cgi_handler_version},
                                     {"/status", cgi_handler_status},
@@ -443,11 +446,63 @@ static const tCGI cgi_handlers[] = {
                                     {"/images", cgi_handler_imgs},
                                     {"/image", cgi_handler_image},
                                     {"/eject", cgi_handler_eject},
-                                    {"/nextImage", cgi_handler_next_image}};
+                                    {"/nextImage", cgi_handler_next_image}
+};
+
+/* Handlers for POST requests */
+
+err_t (*g_httpd_post_receive_data_handler)(void *connection, struct pbuf *p);
+void (*g_httpd_post_finished_handler)(void *connection, char *response_uri, u16_t response_uri_len);
+
+err_t httpd_post_begin(void *connection, const char *uri, const char *http_request,
+                       u16_t http_request_len, int content_len, char *response_uri,
+                       u16_t response_uri_len, u8_t *post_auto_wnd)
+{
+   if (strcmp(uri, "/fw_upgrade.cgi") == 0)
+   {
+      g_httpd_post_receive_data_handler = &fwupgrade_post_receive_data;
+      g_httpd_post_finished_handler = &fwupgrade_post_finished;
+      return fwupgrade_post_begin(connection, uri, http_request, http_request_len, content_len,
+         response_uri, response_uri_len, post_auto_wnd);
+   }
+
+   g_httpd_post_receive_data_handler = nullptr;
+   g_httpd_post_finished_handler = nullptr;
+   return ERR_VAL;
+}
+
+err_t httpd_post_receive_data(void *connection, struct pbuf *p)
+{
+   err_t result = ERR_VAL;
+   if (g_httpd_post_receive_data_handler)
+      result = g_httpd_post_receive_data_handler(connection, p);
+
+   return result;
+}
+
+void httpd_post_finished(void *connection, char *response_uri, u16_t response_uri_len)
+{
+   if (g_httpd_post_finished_handler)
+      g_httpd_post_finished_handler(connection, response_uri, response_uri_len);
+
+   g_httpd_post_receive_data_handler = nullptr;
+   g_httpd_post_finished_handler = nullptr;
+}
+
 void core1_main() {
    zuluide::i2c::client::Init(I2C_SLAVE_SDA_PIN, I2C_SLAVE_SCL_PIN, I2C_SLAVE_ADDRESS, I2C_BAUDRATE);
    multicore_fifo_push_blocking(0xbeef);
    tight_loop_contents();
+}
+
+void start_multicore_i2c() {
+   multicore_launch_core1(core1_main);
+   uint32_t g = multicore_fifo_pop_blocking();
+   if (g == 0xbeef)
+      printf("Core 1 successfully launched");
+   else {
+      printf("Core 1 failed to launch");
+   }
 }
 
 int main() {
@@ -474,15 +529,7 @@ int main() {
    sprintf(versionJson,"{\"clientAPIVersion\":\"%s\", \"serverAPIVersion\": \"server failed to send version\"}", I2C_API_VERSION);
    queue_init(&imageQueue, sizeof(char *), 1);
 
-
-
-   multicore_launch_core1(core1_main);
-   uint32_t g = multicore_fifo_pop_blocking();
-   if (g == 0xbeef)
-      printf("Core 1 successfully launched");
-   else {
-      printf("Core 1 failed to launch");
-   }
+   start_multicore_i2c();
 
    // zuluide::i2c::client::Init(I2C_SLAVE_SDA_PIN, I2C_SLAVE_SCL_PIN, I2C_SLAVE_ADDRESS, I2C_BAUDRATE);
    if (!zuluide::i2c::client::EnqueueRequest(I2C_CLIENT_FETCH_SSID)) {
@@ -679,6 +726,8 @@ int fs_open_custom(struct fs_file *file, const char *name) {
       return get_file_contents(file, doneMessage, strlen(doneMessage));
    } else if (strncmp(name, "/index.html", sizeof("/index.html")) == 0) {
       return get_file_contents(file, index_html, strlen(index_html));
+   } else if (strncmp(name, "/fw_upgrade.html", sizeof("/fw_upgrade.html")) == 0) {
+      return get_file_contents(file, fw_upgrade_html, strlen(fw_upgrade_html));
    } else if (strncmp(name, "/control.js", sizeof("/control.js")) == 0) {
       return get_file_contents(file, control_js, strlen(control_js));
    } else if (strncmp(name, "/style.css", sizeof("/style.css")) == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,6 +118,10 @@ void  ProcessServerAPIVersion(const uint8_t *message, size_t length) {
    char* period_location = strchr(I2C_API_VERSION, '.');
    client_major_version = strtoul(I2C_API_VERSION, &period_location, 10);
 
+   strcat(versionJson, ", \"clientFWVersion\":\"");
+   strcat(versionJson, FW_VERSION);
+   strcat(versionJson, "\"");
+
    if (length > 0)
    {
       serverAPIVersion = std::string((const char*)message);


### PR DESCRIPTION
Adds a link at the bottom of the page where the `.uf2` file can be uploaded for firmware upgrade.
Supports the universal binary .uf2 added in #22.

Tested only on PicoW.