### PR TITLE
Add support to receive firmware file over I2C

### DIFF
--- a/src/ZuluControlI2CClient.cpp
+++ b/src/ZuluControlI2CClient.cpp
@@ -20,10 +20,12 @@
  **/
 
 #include "ZuluControlI2CClient.h"
-
+#include "fw_upgrade.h"
+#include <hardware/sync.h>
+#include <pico/time.h>
 namespace zuluide::i2c::client {
 
-static volatile Packet* current = NULL;
+static volatile Packet* current = nullptr;
 static queue_t outputQueue;
 static queue_t inputQueue;
 static queue_t availInputQueue;
@@ -31,7 +33,7 @@ static queue_t availInputQueue;
 static void i2c_slave_handler(i2c_inst_t* i2c, i2c_slave_event_t event) {
    switch (event) {
       case I2C_SLAVE_RECEIVE: {
-         if (current == NULL) {
+         if (current == nullptr) {
             // Get a buffer.
             static bool input_queue_removed = true;
             if (queue_try_remove(&availInputQueue, &current)) {
@@ -44,24 +46,24 @@ static void i2c_slave_handler(i2c_inst_t* i2c, i2c_slave_event_t event) {
             }
          }
 
-         if (current->state == SendState::None) {
+         if (current->state == ReceiveState::None) {
             if (i2c_get_read_available(i2c0) > 0) {
                current->command = i2c_read_byte_raw(i2c0);
-               current->state = SendState::SentCommand;
+               current->state = ReceiveState::SentCommand;
             }
-         } else if (current->state == SendState::SentCommand) {
+         } else if (current->state == ReceiveState::SentCommand) {
             if (current->pos == 0) {
                if (i2c_get_read_available(i2c0) > 1) {
                   // Both length bytes at once.
                   current->lengthBytes[0] = i2c_read_byte_raw(i2c0);
                   current->lengthBytes[1] = i2c_read_byte_raw(i2c0);
-                  current->state = SendState::SentLength;
+                  current->state = ReceiveState::SentLength;
                   current->pos = 0;
                   current->length = (current->lengthBytes[0] << 8) | current->lengthBytes[1];
                   if (current->length == 0) {
                      // We have now received the entire message.
                      queue_try_add(&inputQueue, &current);
-                     current = NULL;
+                     current = nullptr;
                   }
                } else if (i2c_get_read_available(i2c0) > 0) {
                   // Received the first length byte.
@@ -71,17 +73,17 @@ static void i2c_slave_handler(i2c_inst_t* i2c, i2c_slave_event_t event) {
             } else if (i2c_get_read_available(i2c0) > 0) {
                // Received the second length byte.
                current->lengthBytes[1] = i2c_read_byte_raw(i2c0);
-               current->state = SendState::SentLength;
+               current->state = ReceiveState::SentLength;
                current->pos = 0;
                current->length = (current->lengthBytes[0] << 8) | current->lengthBytes[1];
 
                if (current->length == 0) {
                   // We have now received the entire message.
                   queue_try_add(&inputQueue, &current);
-                  current = NULL;
+                  current = nullptr;
                }
             }
-         } else if (current->state == SendState::SentLength) {
+         } else if (current->state == ReceiveState::SentLength) {
             // Read string data.
             while (current->pos < current->length && i2c_get_read_available(i2c0) > 0) {
                current->buffer[current->pos++] = i2c_read_byte_raw(i2c0);
@@ -90,42 +92,43 @@ static void i2c_slave_handler(i2c_inst_t* i2c, i2c_slave_event_t event) {
             if (current->pos == current->length) {
                // We have now received the entire message.
                queue_try_add(&inputQueue, &current);
-               current = NULL;
+               current = nullptr;
             }
          }
 
          break;
       }
       case I2C_SLAVE_REQUEST: {
-         if (current != NULL) {
-            // Reset if a message wasn't received.
+         if (current != nullptr) {
+            // A write transaction was left incomplete (e.g. the master gave up
+            // partway through). Discard it so stale state doesn't get
+            // mistaken for the start of the next message.
             current->length = 0;
             current->pos = 0;
-            current->state = SendState::None;
-
+            current->state = ReceiveState::None;
             memset((void*)current->buffer, 0, MAX_MSG_SIZE);
             queue_try_add(&availInputQueue, &current);
-            current = NULL;
+            current = nullptr;
          }
 
          Packet* toSend;
          if (queue_try_peek(&outputQueue, &toSend)) {
-            if (toSend->state == SendState::None) {
-               i2c_write_raw_blocking(i2c0, &toSend->command, 1);
-               toSend->state = SendState::SentCommand;
-            } else if (toSend->state == SendState::SentCommand) {
-               i2c_write_raw_blocking(i2c0, toSend->lengthBytes, 2);
-               if (toSend->length > 0) {
-                  toSend->state = SendState::SentLength;
-               } else {
+            if (toSend->state == ReceiveState::None) {
+               uint8_t buffer[3];
+               buffer[0] = toSend->command;
+               buffer[1] = toSend->lengthBytes[0];
+               buffer[2] = toSend->lengthBytes[1];
+               i2c_write_raw_blocking(i2c0, buffer, 3);
+               if (toSend->length == 0) {
                   // Cleanup, sent a request without a string payload.
                   if (!queue_try_remove(&outputQueue, &toSend)) {
-                     printf("Unable to remove from queue.");
+                     printf("Unable to remove from queue.\n");
                   }
-
-                  delete toSend;
+                     delete toSend;
+                  } else {
+                  toSend->state = ReceiveState::SentLength;
                }
-            } else if (toSend->state == SendState::SentLength) {
+            } else if (toSend->state == ReceiveState::SentLength) {
                // Send out the message.
                if ((toSend->length - toSend->pos) > BUFFER_LENGTH) {
                   i2c_write_raw_blocking(i2c0, toSend->buffer + toSend->pos, BUFFER_LENGTH);
@@ -141,9 +144,10 @@ static void i2c_slave_handler(i2c_inst_t* i2c, i2c_slave_event_t event) {
             }
          } else {
             // Send NOOP for the
-            i2c_write_byte_raw(i2c0, I2C_CLIENT_NOOP);
+            uint8_t buffer[3] = {0};
+            buffer[0] = I2C_CLIENT_NOOP;
+            i2c_write_raw_blocking(i2c0, buffer, 3);
          }
-
          break;
       }
       case I2C_SLAVE_FINISH: {
@@ -168,7 +172,7 @@ bool EnqueueRequest(uint8_t request) {
    p->length = 0;
    p->command = request;
    p->pos = 0;
-   p->state = SendState::None;
+   p->state = ReceiveState::None;
    if (!queue_try_add(&outputQueue, &p)) {
       delete p;
       return false;
@@ -187,7 +191,7 @@ bool EnqueueRequest(uint8_t request, const char* toSend) {
    p->lengthBytes[0] = p->length >> 8;
    p->lengthBytes[1] = p->length;
    p->pos = 0;
-   p->state = SendState::None;
+   p->state = ReceiveState::None;
    memcpy(p->buffer, toSend, p->length);
    if (!queue_try_add(&outputQueue, &p)) {
       delete p;
@@ -196,7 +200,21 @@ bool EnqueueRequest(uint8_t request, const char* toSend) {
    return true;
 }
 
+void WaitForOutputQueueDrain(uint32_t timeout_ms) {
+   uint32_t start = to_ms_since_boot(get_absolute_time());
+   while (!queue_is_empty(&outputQueue)) {
+      if ((uint32_t)(to_ms_since_boot(get_absolute_time()) - start) >= timeout_ms) {
+         break;
+      }
+      sleep_ms(1);
+   }
+}
+
 bool EnqueueRequestBinary(uint8_t request, const uint8_t* payload, uint16_t length) {
+   if (payload == nullptr) {
+      return false;
+   }
+
    if (queue_is_full(&outputQueue))
    {
       EnqueueRequest(I2C_CLIENT_RESET_QUEUE);
@@ -208,10 +226,8 @@ bool EnqueueRequestBinary(uint8_t request, const uint8_t* payload, uint16_t leng
    p->lengthBytes[0] = p->length >> 8;
    p->lengthBytes[1] = p->length;
    p->pos = 0;
-   p->state = SendState::None;
-   if (length > 0 && payload != nullptr) {
-      memcpy(p->buffer, payload, length);
-   }
+   p->state = ReceiveState::None;
+   memcpy(p->buffer, payload, length);
    if (!queue_try_add(&outputQueue, &p)) {
       delete p;
       return false;
@@ -238,10 +254,21 @@ void Init(uint sdaPin, uint sclPin, uint addr, uint baudrate) {
    i2c_init(i2c0, baudrate);
    i2c_slave_init(i2c0, addr, &i2c_slave_handler);
 
-   // Initalize data structures for synchronizing between I2C interrupt and the main process.
-   queue_init(&outputQueue, sizeof(Packet*), 20);
-   queue_init(&inputQueue, sizeof(zuluide::i2c::client::Packet*), INPUT_BUFFER_COUNT);
-   queue_init(&availInputQueue, sizeof(zuluide::i2c::client::Packet*), INPUT_BUFFER_COUNT);
+   // Initialize data structures for synchronizing between I2C interrupt and the main process.
+   //
+   // Use explicitly claimed spinlocks (from the SDK's reserved "claim free" range) instead of
+   // queue_init()'s default striped-pool allocation. The striped pool only has 8 IDs and is
+   // shared, via round-robin, with everything else in the program that also uses it -
+   // including multicore_lockout's internal mutex, which is lazily initialized on its first
+   // use (during an I2C firmware upgrade's flash erase/program). If that mutex happens to land
+   // on the same physical spinlock number as one of these queues, the queue's synchronization
+   // gets silently corrupted the moment a lockout is used, and it never recovers on its own.
+   int outputSpinlock = spin_lock_claim_unused(true);
+   int inputSpinlock = spin_lock_claim_unused(true);
+   int availSpinlock = spin_lock_claim_unused(true);
+   queue_init_with_spinlock(&outputQueue, sizeof(Packet*), 20, outputSpinlock);
+   queue_init_with_spinlock(&inputQueue, sizeof(zuluide::i2c::client::Packet*), INPUT_BUFFER_COUNT, inputSpinlock);
+   queue_init_with_spinlock(&availInputQueue, sizeof(zuluide::i2c::client::Packet*), INPUT_BUFFER_COUNT, availSpinlock);
 
    for (int i = 0; i < INPUT_BUFFER_COUNT; i++) {
       auto p = new Packet();
@@ -253,7 +280,7 @@ void Cleanup(Packet* packet) {
    // Cleanup buffer and put back into service.
    packet->length = 0;
    packet->pos = 0;
-   packet->state = SendState::None;
+   packet->state = ReceiveState::None;
    memset(packet->buffer, 0, MAX_MSG_SIZE);
    queue_try_add(&availInputQueue, &packet);
 }
@@ -295,6 +322,12 @@ void ProcessMessages() {
          ProcessDeviceList(toRecv->buffer, toRecv->length);
       } else if (Is(toRecv, I2C_SERVER_SD_STATUS_CHANGE)) {
          ProcessSDStatus(toRecv->buffer, toRecv->length);
+      } else if (Is(toRecv, I2C_SERVER_UPDATE_FW_REQUEST)) {
+         ProcessUpgradeFirmwareRequest(toRecv->buffer, toRecv->length);
+      } else if (Is(toRecv, I2C_SERVER_UPDATE_FW_DATA)) {
+         ProcessUpgradeFirmwareData(toRecv->buffer, toRecv->length);
+      } else {
+         printf("Unknown message received: %02X\n", toRecv->command);
       }
 
 

--- a/src/ZuluControlI2CClient.h
+++ b/src/ZuluControlI2CClient.h
@@ -22,7 +22,7 @@
 #ifndef ZULU_CONTROL_I2C_CLIENT
 #define ZULU_CONTROL_I2C_CLIENT
 
-#define I2C_API_VERSION "4.0.0"
+#define I2C_API_VERSION "5.0.0"
 
 #ifndef FW_GITHASH
 #define FW_GITHASH ""

--- a/src/ZuluControlI2CClient.h
+++ b/src/ZuluControlI2CClient.h
@@ -37,6 +37,8 @@
 
 #define I2C_SERVER_API_VERSION  0x1
 #define I2C_SERVER_WIFI_CONNECT 0x2
+#define I2C_SERVER_UPDATE_FW_REQUEST 0x3   // Server requests the client to start, stop, or abort a firmware upgrade
+#define I2C_SERVER_UPDATE_FW_DATA 0x4      // Server sends a chunk of firmware data to the client
 #define I2C_SERVER_UPDATE_FILENAME_CACHE 0x8
 #define I2C_SERVER_IMAGE_FILENAME 0x9
 #define I2C_SERVER_SYSTEM_STATUS_JSON 0xA
@@ -52,8 +54,17 @@
 #define I2C_SERVER_SD_NOT_PRESENT 0x00
 #define I2C_SERVER_SD_PRESENT     0x01
 
+#define I2C_SERVER_FW_UPGRADE_START 0x00
+#define I2C_SERVER_FW_UPGRADE_FINISH 0x01
+#define I2C_SERVER_FW_UPGRADE_ABORT 0x02
+#define I2C_SERVER_FW_UPGRADE_RETRY 0x03
+
+
 #define I2C_CLIENT_NOOP 0x0
 #define I2C_CLIENT_API_VERSION 0x01
+#define I2C_CLIENT_UPDATE_FW_ACK 0x03
+#define I2C_CLIENT_ACK_SPECIAL_LEN 0xFFFF
+#define I2C_CLIENT_ACK_CRC_UPGRADE_COMPLETE 0x00000000
 #define I2C_CLIENT_FETCH_FILENAMES 0x09
 #define I2C_CLIENT_SUBSCRIBE_STATUS_JSON 0xA
 #define I2C_CLIENT_LOAD_IMAGE 0xB
@@ -86,7 +97,7 @@
 #include <cstring>
 
 namespace zuluide::i2c::client {
-enum class SendState { None,
+enum class ReceiveState { None,
                        SentCommand,
                        SentLength };
 
@@ -100,7 +111,7 @@ typedef struct {
    uint16_t length;
    uint8_t lengthBytes[2];
    uint8_t buffer[MAX_MSG_SIZE];
-   SendState state;
+   ReceiveState state;
 } Packet;
 
 /**
@@ -117,6 +128,15 @@ bool EnqueueRequest(uint8_t request, const char* toSend);
    Enqueues a request with a raw binary payload (used for ZuluSCSI scsi_id-prefixed commands).
  */
 bool EnqueueRequestBinary(uint8_t request, const uint8_t* payload, uint16_t length);
+
+/**
+   Busy-polls (sleeping 1ms between checks) until the outbound message queue
+   has been fully drained by the I2C slave ISR on core1, or timeout_ms
+   elapses. Used by the firmware-upgrade completion path to make sure a
+   final ACK has actually gone out over the wire before core1 -- which
+   drives that ISR -- gets reset.
+ */
+void WaitForOutputQueueDrain(uint32_t timeout_ms);
 
 /**
    Resets the request queue
@@ -215,6 +235,21 @@ bool TryReceive(Packet** packet);
    Executes the message processing and dispatching loop.
  */
 void ProcessMessages();
+
+/**
+   Called when the server requests a firmware upgrade (start/finish/abort/retry).
+ */
+void ProcessUpgradeFirmwareRequest(const uint8_t* message, size_t length);
+
+/**
+   Called when a chunk of ZuluControl-firmware data is received from the server.
+   Computes the chunk's CRC32 in software, stages it (does not flash it yet --
+   see fw_upgrade.h's stage-then-commit design), and acks back the length and
+   CRC32 the client actually received so the server can decide whether to retry.
+ */
+void ProcessUpgradeFirmwareData(const uint8_t* message, size_t length);
+
 }  // namespace zuluide::i2c::client
+
 
 #endif

--- a/src/fw_upgrade.cpp
+++ b/src/fw_upgrade.cpp
@@ -20,10 +20,13 @@
  **/
 
 #include "fw_upgrade.h"
+#include "ZuluControlI2CClient.h"
 #include <hardware/sync.h>
 #include <hardware/flash.h>
+#include <hardware/gpio.h>
 #include <hardware/structs/scb.h>
 #include <pico/multicore.h>
+#include <pico/time.h>
 #include "lwip/apps/fs.h"
 #include "lwip/apps/httpd.h"
 #include "lwip/def.h"
@@ -31,6 +34,11 @@
 #include "lwip/opt.h"
 #include "boot/uf2.h"
 #include <string.h>
+
+// User LED GPIO, defined in main.cpp -- gpio_put() on a pin whose function/
+// direction hasn't been configured (non-board-type-B boards) is a harmless
+// no-op, same assumption the rest of the LED call sites in main.cpp rely on.
+extern const uint8_t GPIO_MCU_LED;
 
 #if PICO_RP2350
 #define UF2_FAMILY_ID RP2350_ARM_S_FAMILY_ID
@@ -54,6 +62,8 @@ static struct {
     uf2_block block;
     uint32_t blocks_received;
     uint32_t num_blocks;
+    uint8_t staged[MAX_MSG_SIZE];
+    size_t staged_len;
 } g_fwup_state;
 
 err_t fwupgrade_post_begin(void *connection, const char *uri, const char *http_request,
@@ -64,8 +74,20 @@ err_t fwupgrade_post_begin(void *connection, const char *uri, const char *http_r
     g_fwup_state.block_size = 0;
     g_fwup_state.blocks_received = 0;
     g_fwup_state.num_blocks = 0;
+    gpio_put(GPIO_MCU_LED, false);
     return ERR_OK;
 }
+
+void fwupgrade_i2c_begin()
+{
+    printf("I2C firmware upgrade begining\n");
+    g_fwup_state.block_size = 0;
+    g_fwup_state.blocks_received = 0;
+    g_fwup_state.num_blocks = 0;
+    g_fwup_state.staged_len = 0;
+    gpio_put(GPIO_MCU_LED, false);
+}
+
 
 // Erase whole flash area before programming it
 __attribute__((section(".time_critical.erase_flash_area")))
@@ -129,8 +151,11 @@ int64_t finish_fw_upgrade(alarm_id_t id, void *user_data)
     while(1);
 }
 
-static bool handle_uf2_block(uf2_block *block)
+static bool handle_uf2_block(uf2_block *block, bool stop_second_core = true)
 {
+    static uint32_t last_progress_log_ms = 0;
+    uint32_t now_ms = to_ms_since_boot(get_absolute_time());
+
     if (block->magic_start0 != UF2_MAGIC_START0 ||
         block->magic_start1 != UF2_MAGIC_START1 ||
         block->magic_end != UF2_MAGIC_END)
@@ -140,13 +165,38 @@ static bool handle_uf2_block(uf2_block *block)
         return false;
     }
 
+    static uint32_t s_last_family_block = UF2_FAMILY_ID;
+    static uint8_t s_dot_count = 0;
+
     if (block->file_size != UF2_FAMILY_ID || !(block->flags & UF2_FLAG_FAMILY_ID_PRESENT))
     {
-        printf("Ignoring block for different family id (expected 0x%08x, got 0x%08lx)\n",
-            UF2_FAMILY_ID, block->file_size);
+        if (s_last_family_block != block->file_size)
+        {
+            printf("Ignoring block for different family id (expected 0x%08x, got 0x%08lx)\n",
+                UF2_FAMILY_ID, block->file_size);
+            s_last_family_block =  block->file_size;
+        }
+        else if ((uint32_t)(now_ms - last_progress_log_ms) >= 2000)
+        {
+            last_progress_log_ms = now_ms;
+            printf(".");
+            if (s_dot_count > 20)
+            {
+                printf("\n");
+                s_dot_count = 0;
+            }
+            else
+            {
+                s_dot_count++;
+            }
+        }
 
         // Continue upload until we get a block for us in a universal binary
         return true;
+    }
+    else
+    {
+        s_dot_count = 0;
     }
 
     if (block->flags & UF2_FLAG_NOT_MAIN_FLASH)
@@ -174,8 +224,11 @@ static bool handle_uf2_block(uf2_block *block)
         g_fwup_state.blocks_received = 0;
         g_fwup_state.num_blocks = block->num_blocks;
 
-        printf("Stopping second core\n");
-        multicore_reset_core1();
+        if (stop_second_core)
+        {
+            printf("Stopping second core\n");
+            multicore_reset_core1();
+        }
     }
     else if (block->block_no != g_fwup_state.blocks_received)
     {
@@ -187,22 +240,36 @@ static bool handle_uf2_block(uf2_block *block)
     uint32_t block_offset = block->target_addr - FW_UPGRADE_TARGET_ADDR;
     uint32_t tmp_addr = FW_UPGRADE_TEMP_OFFSET + block_offset;
 
+    // Core1 lockout (when needed) is acquired once by the caller around the
+    // whole run of blocks in a commit, not per block -- see fwupgrade_i2c_commit_staged.
+
     // Erase one sector at a time just before it is first needed.
     // This keeps each interrupt-disabled period under ~50ms instead of
     // erasing the entire temp area (5+ seconds) upfront on block 0.
     if (block_offset % FLASH_SECTOR_ERASE_SIZE == 0)
     {
-        printf("Erasing sector at %lu\n", tmp_addr);
         erase_flash_area(tmp_addr, FLASH_SECTOR_ERASE_SIZE);
     }
-    printf("Programming UF2 block %lu/%lu to %lu\n", block->block_no, block->num_blocks, tmp_addr);
-    if (!program_flash_block(tmp_addr, block->data))
+    bool program_ok = program_flash_block(tmp_addr, block->data);
+    if (!program_ok)
     {
         printf("Programming UF2 block to temporary flash failed at addr %lu\n", tmp_addr);
         return false;
     }
-    printf("Block programming successful\n");
     g_fwup_state.blocks_received++;
+
+    // Fast LED blink, one toggle per flash block written.
+    gpio_put(GPIO_MCU_LED, (g_fwup_state.blocks_received & 1) != 0);
+
+    // Log progress at most every 2 seconds rather than every block
+    bool last_block = (g_fwup_state.blocks_received == block->num_blocks);
+    if ((uint32_t)(now_ms - last_progress_log_ms) >= 2000 || last_block)
+    {
+        last_progress_log_ms = now_ms;
+        uint32_t percent = block->num_blocks ? (g_fwup_state.blocks_received * 100 / block->num_blocks) : 0;
+        printf("Programming UF2 block %lu/%lu (%lu%%)\n",
+               g_fwup_state.blocks_received, block->num_blocks, percent);
+    }
 
     return true;
 }
@@ -245,6 +312,76 @@ err_t fwupgrade_post_receive_data(void *connection, struct pbuf *p)
     return ERR_OK;
 }
 
+bool fwupgrade_i2c_stage_chunk(const uint8_t *data, size_t length)
+{
+    if (length > sizeof(g_fwup_state.staged))
+    {
+        printf("fwupgrade_i2c_stage_chunk: length %zu exceeds staging buffer\n", length);
+        return false;
+    }
+
+    memcpy(g_fwup_state.staged, data, length);
+    g_fwup_state.staged_len = length;
+    return true;
+}
+
+bool fwupgrade_i2c_commit_staged()
+{
+    if (g_fwup_state.staged_len == 0)
+    {
+        return true;
+    }
+
+    const uint8_t *data = g_fwup_state.staged;
+    size_t remain = g_fwup_state.staged_len;
+    g_fwup_state.staged_len = 0;
+
+    // Core1 (running the I2C slave ISR) is left running during the I2C upgrade
+    // path so it can keep servicing the bus while we flash. Core1 executes from
+    // flash just like core0, so it must be safely parked in RAM (via the lockout
+    // mechanism) for the duration of any erase/program call, or it can stall/hang
+    // fetching an instruction from flash mid-erase. Acquired once here for the
+    // whole staged chunk (all its uf2_blocks) instead of once per block, since
+    // each lockout round trip costs a fixed signalling overhead independent of
+    // how much flash work happens while it's held.
+    bool locked = multicore_lockout_start_timeout_us(2000000);
+    if (!locked) printf("Lockout start failed\n");
+
+    bool ok = true;
+    while (remain > 0)
+    {
+        size_t block_remain = sizeof(uf2_block) - g_fwup_state.block_size;
+        size_t to_cpy = (remain > block_remain) ? block_remain : remain;
+        memcpy((uint8_t*)&g_fwup_state.block + g_fwup_state.block_size, data, to_cpy);
+        g_fwup_state.block_size += to_cpy;
+        data += to_cpy;
+        remain -= to_cpy;
+        if (g_fwup_state.block_size == sizeof(uf2_block))
+        {
+            if (!handle_uf2_block(&g_fwup_state.block, false))  // Don't stop multicore for I2C
+            {
+                printf("handle_uf2_block() failed\n");
+                ok = false;
+                break;
+            }
+            g_fwup_state.block_size = 0;
+        }
+    }
+
+    bool unlocked = multicore_lockout_end_timeout_us(2000000);
+    if (!unlocked) printf("Lockout end failed\n");
+    // multicore_lockout_end_* only confirms core0's own signal was sent, not that
+    // core1 actually finished exiting its wait loop and resumed normal execution.
+    // Give it a guaranteed window to do so before touching it again.
+    sleep_us(1000);
+
+    return ok;
+}
+
+void fwupgrade_i2c_discard_staged()
+{
+    g_fwup_state.staged_len = 0;
+}
 void start_multicore_i2c();
 
 void fwupgrade_post_finished(void *connection, char *response_uri, u16_t response_uri_len)
@@ -254,6 +391,7 @@ void fwupgrade_post_finished(void *connection, char *response_uri, u16_t respons
     {
         printf("fwupgrade interrupted, %lu/%lu blocks done\n",
             g_fwup_state.blocks_received, g_fwup_state.num_blocks);
+        gpio_put(GPIO_MCU_LED, false);
 
         if (g_fwup_state.num_blocks > 0)
         {
@@ -268,6 +406,50 @@ void fwupgrade_post_finished(void *connection, char *response_uri, u16_t respons
 
         // Let lwip post the result and then proceed to copy the firmware to the actual
         // location and reboot.
+        add_alarm_in_ms(500, finish_fw_upgrade, NULL, false);
+    }
+}
+
+
+void fwupgrade_i2c_finished()
+{
+    fwupgrade_i2c_commit_staged();
+
+    if (g_fwup_state.num_blocks == 0 ||
+        g_fwup_state.blocks_received != g_fwup_state.num_blocks)
+    {
+        printf("I2C firmware upgrade interrupted, %lu/%lu blocks done\n",
+            g_fwup_state.blocks_received, g_fwup_state.num_blocks);
+        gpio_put(GPIO_MCU_LED, false);
+
+        if (g_fwup_state.num_blocks > 0)
+        {
+            // We reset multicore so restore it back to operation
+            start_multicore_i2c();
+        }
+    }
+    else
+    {
+        // Tell the host the update succeeded and this device is about to
+        // reboot into it, via a sentinel ACK the host recognizes as
+        // distinct from a normal chunk ack: length 0xFFFF, crc32
+        // 0x00000000. No real chunk ack can ever produce that length --
+        // chunks are capped at I2C_UPGRADE_MAX_CHUNK bytes -- so it can't
+        // be confused with one. Sent through the same ACK command/queue as
+        // a normal chunk ack, so the host's existing
+        // UpgradeZuluControlFwReadAck() reads it with no changes needed.
+        uint8_t sentinelAck[6] = { 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00 };
+        zuluide::i2c::client::EnqueueRequestBinary(I2C_CLIENT_UPDATE_FW_ACK, sentinelAck, sizeof(sentinelAck));
+
+        // Core1 drives the I2C slave ISR that actually puts bytes on the
+        // wire -- give the ACK a chance to be fully sent before resetting
+        // it below, or the host would never see it.
+        zuluide::i2c::client::WaitForOutputQueueDrain(2000);
+
+        printf("I2C firmware upgrade finished. Rebooting\n");
+
+        // location and reboot.
+        multicore_reset_core1();
         add_alarm_in_ms(500, finish_fw_upgrade, NULL, false);
     }
 }

--- a/src/fw_upgrade.h
+++ b/src/fw_upgrade.h
@@ -35,3 +35,24 @@ err_t fwupgrade_post_receive_data(void *connection, struct pbuf *p);
 
 // Called from http_post_finished
 void fwupgrade_post_finished(void *connection, char *response_uri, u16_t response_uri_len);
+
+// These are the functions that upgrade over I2C
+void fwupgrade_i2c_begin();
+
+// Copies `data` (a chunk just received over I2C, not yet confirmed good) into
+// the staging buffer. Pure memcpy + bookkeeping, no flash access -- safe to
+// call from core0's ordinary message-processing loop.
+bool fwupgrade_i2c_stage_chunk(const uint8_t *data, size_t length);
+
+// Runs the per-uf2_block split + handle_uf2_block loop over whatever is
+// currently staged, committing it (erasing/programming flash as needed). A
+// no-op returning true if nothing is staged. Must be called from core0.
+bool fwupgrade_i2c_commit_staged();
+
+// Discards whatever is currently staged without committing it -- used when
+// the host sends RETRY (it detected a CRC/length mismatch on the chunk it
+// just acked, so the client must forget it; it will be resent). Pure
+// bookkeeping, no flash access.
+void fwupgrade_i2c_discard_staged();
+
+void fwupgrade_i2c_finished();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,13 +47,14 @@
 #include "url_decode.h"
 
 static const uint I2C_SLAVE_ADDRESS = 0x45;
-static const uint I2C_BAUDRATE = 400000;  // 400 kHz
+static const uint I2C_BAUDRATE = 400000;  // 400 kHz (Fast Mode)
 
 static const uint I2C_SLAVE_SDA_PIN = 0;
 static const uint I2C_SLAVE_SCL_PIN = 1;
 
 static const uint8_t GPIO_BOARD_TYPE = 5;
-static const uint8_t GPIO_MCU_LED    = 26;
+
+extern const uint8_t GPIO_MCU_LED = 26;
 
 static const uint8_t MAX_SCSI_IDS = 16;
 
@@ -132,6 +133,7 @@ enum class State {
     WaitingForConnect,
     WIFIInit,
     WIFIDown,
+    FirmwareUpgradeI2C,
     Normal
 };
 
@@ -502,6 +504,88 @@ void ProcessSDStatus(const uint8_t *message, size_t length)
     printf("SD card %s\n", g_sd_present ? "present" : "not present");
 }
 
+void ProcessUpgradeFirmwareRequest(const uint8_t* message, size_t length) {
+   if (length != 1) {
+      printf("Invalid firmware upgrade request received.\n");
+      return;
+   }
+
+   uint8_t requestType = message[0];
+   switch (requestType) {
+      case I2C_SERVER_FW_UPGRADE_START:
+         printf("Firmware upgrade request received: START\n");
+         fwupgrade_i2c_begin();
+         programState = State::FirmwareUpgradeI2C;
+         break;
+      case I2C_SERVER_FW_UPGRADE_FINISH:
+         printf("Firmware upgrade request received: FINISH\n");
+         fwupgrade_i2c_finished();
+         programState = State::WaitForAPIVersion;
+         break;
+      case I2C_SERVER_FW_UPGRADE_ABORT:
+         printf("Firmware upgrade request received: ABORT\n");
+         fwupgrade_i2c_begin();
+         programState = State::WaitForAPIVersion;
+         break;
+      case I2C_SERVER_FW_UPGRADE_RETRY:
+         // Host detected a CRC/length mismatch on the chunk it just acked --
+         // discard the staged data (it will be resent) without committing it.
+         printf("Firmware upgrade request received: RETRY\n");
+         fwupgrade_i2c_discard_staged();
+         break;
+      default:
+         printf("Unknown firmware upgrade request received: %02X\n", requestType);
+         break;
+   }
+}
+
+// Table-driven software CRC32, reflected CRC-32/ISO-HDLC (aka the
+// zlib/gzip/PNG/Ethernet CRC32), polynomial 0xEDB88320 (the bit-reversed
+// form of 0x04C11DB7), seed 0xFFFFFFFF, final XOR 0xFFFFFFFF -- so the
+// client computes its own CRC in software as it receives each chunk over
+// the ordinary byte-ISR path.
+static uint32_t g_crc32_table[256];
+static bool g_crc32_table_ready = false;
+
+static void Crc32TableInit() {
+   for (uint32_t i = 0; i < 256; i++) {
+      uint32_t c = i;
+      for (int k = 0; k < 8; k++) {
+         c = (c & 1u) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+      }
+      g_crc32_table[i] = c;
+   }
+   g_crc32_table_ready = true;
+}
+
+static uint32_t Crc32(const uint8_t* data, size_t length) {
+   if (!g_crc32_table_ready) Crc32TableInit();
+   uint32_t crc = 0xFFFFFFFFu;
+   for (size_t i = 0; i < length; i++) {
+      crc = g_crc32_table[(crc ^ data[i]) & 0xFF] ^ (crc >> 8);
+   }
+   return crc ^ 0xFFFFFFFFu;
+}
+
+void ProcessUpgradeFirmwareData(const uint8_t* message, size_t length) {
+   // Implicit confirmation: receiving a *new* chunk means the host got a
+   // matching-CRC ack for the *previous* one and is proceeding, so it's now
+   // safe to commit (flash) the previously staged chunk.
+   fwupgrade_i2c_commit_staged();
+
+   uint32_t crc = Crc32(message, length);
+   fwupgrade_i2c_stage_chunk(message, length);
+
+   uint8_t ackPayload[6];
+   ackPayload[0] = (length >> 8) & 0xFF;
+   ackPayload[1] = length & 0xFF;
+   ackPayload[2] = (crc >> 24) & 0xFF;
+   ackPayload[3] = (crc >> 16) & 0xFF;
+   ackPayload[4] = (crc >> 8) & 0xFF;
+   ackPayload[5] = crc & 0xFF;
+   EnqueueRequestBinary(I2C_CLIENT_UPDATE_FW_ACK, ackPayload, sizeof(ackPayload));
+}
+
 }  // namespace zuluide::i2c::client
 
 // ── CGI handlers ─────────────────────────────────────────────────────────────
@@ -768,6 +852,10 @@ void httpd_post_finished(void *connection, char *response_uri, u16_t response_ur
 // ── Core 1 (I2C slave) ────────────────────────────────────────────────────────
 
 void core1_main() {
+    // Lets core0 safely park us in RAM (via multicore_lockout_start_blocking()) while it
+    // erases/programs flash during an I2C firmware upgrade, instead of us stalling/hanging
+    // trying to fetch code from the flash core0 currently has locked for the erase/program.
+    multicore_lockout_victim_init();
     zuluide::i2c::client::Init(I2C_SLAVE_SDA_PIN, I2C_SLAVE_SCL_PIN, I2C_SLAVE_ADDRESS, I2C_BAUDRATE);
     multicore_fifo_push_blocking(0xbeef);
     while (true) { tight_loop_contents(); }
@@ -858,6 +946,7 @@ int main() {
                         printf("Failed to add request for SSID to output queue\n");
                     }
                     waiting_start = millis();
+                    printf("Waiting for SSID from server");
                 }
                 last_state = programState;
                 zuluide::i2c::client::ProcessMessages();
@@ -986,6 +1075,11 @@ int main() {
                 break;
             }
 
+            case State::FirmwareUpgradeI2C: {
+                last_state = programState;
+                zuluide::i2c::client::ProcessMessages();
+                break;
+            }
             default:
                 last_state = State::Unknown;
                 printf("Error, unknown state.\n");


### PR DESCRIPTION
The `zulucontrol.uf2` file can now be ingested over I2C.