### PR TITLE
Remove extra "SD Card:" on main page

### DIFF
--- a/resources/control.html
+++ b/resources/control.html
@@ -15,7 +15,6 @@
           <h1>ZuluIDE Control</h1>
           <div>SD Card: <span id='ide-sd'></span></div>
           <div id='ide-st'>
-            SD Card: <span id='ide-sd'></span><br/>
             Image: <span id='ide-img' class='wrap'></span><br/>
             <button onclick='ideEjectClk()'>&#x23CF;</button><button onclick='ideSelectClk()'>&#x1F4bF;</button>
             <br/>


### PR DESCRIPTION
Removed extra "SD Card:" text on ZuluIDE page.